### PR TITLE
Measure update speed

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,17 +118,17 @@ async function run () {
     sections.push(stripIndents`
       ${fixture.mdDesc}
 
-      | action               | cache | lockfile | node_modules| npm | Yarn | pnpm |
-      | ---                  | ---   | ---      | ---         | --- | --- | --- |
-      | install              |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} |
-      | install              | ✔    | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} |
-      | install              | ✔    | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} |
-      | install              | ✔    |          |             | ${prettyMs(npmRes.withWarmCache)} | ${prettyMs(yarnRes.withWarmCache)} | ${prettyMs(pnpmRes.withWarmCache)} |
-      | install              |      | ✔        |             | ${prettyMs(npmRes.withLockfile)} | ${prettyMs(yarnRes.withLockfile)} | ${prettyMs(pnpmRes.withLockfile)} |
-      | install              | ✔    |          | ✔           | ${prettyMs(npmRes.withWarmCacheAndModules)} | ${prettyMs(yarnRes.withWarmCacheAndModules)} | ${prettyMs(pnpmRes.withWarmCacheAndModules)} |
-      | install              |      | ✔        | ✔           | ${prettyMs(npmRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnRes.withWarmModulesAndLockfile)} | ${prettyMs(pnpmRes.withWarmModulesAndLockfile)} |
-      | install              |      |          | ✔           | ${prettyMs(npmRes.withWarmModules)} | ${prettyMs(yarnRes.withWarmModules)} | ${prettyMs(pnpmRes.withWarmModules)} |
-      | updated dependencies | n/a  | n/a      | n/a         | ${prettyMs(npmRes.updatedDependencies)} | ${prettyMs(yarnRes.updatedDependencies)} | ${prettyMs(pnpmRes.updatedDependencies)} |
+      | action  | cache | lockfile | node_modules| npm | Yarn | pnpm |
+      | ---     | ---   | ---      | ---         | --- | --- | --- |
+      | install |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} |
+      | install | ✔     | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} |
+      | install | ✔     | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} |
+      | install | ✔     |          |             | ${prettyMs(npmRes.withWarmCache)} | ${prettyMs(yarnRes.withWarmCache)} | ${prettyMs(pnpmRes.withWarmCache)} |
+      | install |       | ✔        |             | ${prettyMs(npmRes.withLockfile)} | ${prettyMs(yarnRes.withLockfile)} | ${prettyMs(pnpmRes.withLockfile)} |
+      | install | ✔     |          | ✔           | ${prettyMs(npmRes.withWarmCacheAndModules)} | ${prettyMs(yarnRes.withWarmCacheAndModules)} | ${prettyMs(pnpmRes.withWarmCacheAndModules)} |
+      | install |       | ✔        | ✔           | ${prettyMs(npmRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnRes.withWarmModulesAndLockfile)} | ${prettyMs(pnpmRes.withWarmModulesAndLockfile)} |
+      | install |       |          | ✔           | ${prettyMs(npmRes.withWarmModules)} | ${prettyMs(yarnRes.withWarmModules)} | ${prettyMs(pnpmRes.withWarmModules)} |
+      | update  | n/a   | n/a      | n/a         | ${prettyMs(npmRes.updatedDependencies)} | ${prettyMs(yarnRes.updatedDependencies)} | ${prettyMs(pnpmRes.updatedDependencies)} |
 
       ![Graph of the ${fixture.name} results](./results/imgs/${fixture.name}.svg)
     `)
@@ -151,11 +151,11 @@ async function run () {
   const explanation = stripIndents`
   Here's a quick explanation of all tests:
 
-  - \`clean install\`: How long it takes to run a totally fresh install: no lockfile created, no packages in the cache, no \`node_modules\` folder.
+  - \`clean install\`: How long it takes to run a totally fresh install: no lockfile present, no packages in the cache, no \`node_modules\` folder.
   - \`with cache\`, \`with lockfile\`, \`with node_modules\`: After the first install is done, the install command is run again.
-  - \`with cache\`, \`with lockfile\`: \`node_modules\` are deleted and the install command is run again.
-  - \`with cache\`: \`node_modules\` and the lockfile are deleted and the install command is run again.
-  - \`with lockfile\`: \`node_modules\` and the package cache are deleted and the install command is run again.
+  - \`with cache\`, \`with lockfile\`: When a repo is fetched by a developer and installation is first run.
+  - \`with cache\`: Same as the one above, but the package manager doesn't have a lockfile to work from.
+  - \`with lockfile\`: When an installation runs on a CI server.
   - \`with cache\`, \`with node_modules\`: The lockfile is deleted and the install command is run again.
   - \`with node_modules\`, \`with lockfile\`: The package cache is deleted and the install command is run again.
   - \`with node_modules\`: The package cache and the lockfile is deleted and the install command is run again.

--- a/index.js
+++ b/index.js
@@ -141,13 +141,32 @@ async function run () {
   // make sure folder exists
   mkdirp.sync(join(__dirname, 'results', 'imgs'))
 
+  const introduction = stripIndents`
+  # Benchmarks of JavaScript Package Managers
+
+  This benchmark compares the performance of [npm](https://github.com/npm/cli), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
+  `
+
+  const explanation = stripIndents`
+  Here's a quick explanation of all tests:
+  -\`clean install\`: How long it takes to run a totally fresh install: no lockfile created, no packages in the cache, no \`node_modules\` folder.
+  -\`with cache\`, \`with lockfile\`, \`with node_modules\`: After the first install is done, the install command is run again.
+  -\`with cache\`, \`with lockfile\`: \`node_modules\` are deleted and the install command is run again.
+  -\`with cache\`: \`node_modules\` and the lockfile are deleted and the install command is run again.
+  -\`with lockfile\`: \`node_modules\` and the package cache are deleted and the install command is run again.
+  -\`with cache\`, \`with node_modules\`: The lockfile is deleted and the install command is run again.
+  -\`with node_modules\`, \`with lockfile\`: The package cache is deleted and the install command is run again.
+  -\`with node_modules\`: The package cache and the lockfile is deleted and the install command is run again.
+  -\`updated dependencies\`: Without deleting the previous installation the versions of all dependencies in the \`package.json\` are set to \`'*'\` and the install command is run again.
+`
+
   await Promise.all(
     [
       Promise.all(svgs.map((file) => writeFile(file.path, file.file, 'utf-8'))),
       writeFile('README.md', stripIndents`
-        # Benchmarks of JavaScript Package Managers
+        ${introduction}
 
-        This benchmark compares the performance of [npm](https://github.com/npm/cli), [pnpm](https://github.com/pnpm/pnpm) and [yarn](https://github.com/yarnpkg/yarn).
+        ${explanation}
 
         ${sections.join('\n\n')}`, 'utf8')
     ]

--- a/index.js
+++ b/index.js
@@ -149,15 +149,16 @@ async function run () {
 
   const explanation = stripIndents`
   Here's a quick explanation of all tests:
-  -\`clean install\`: How long it takes to run a totally fresh install: no lockfile created, no packages in the cache, no \`node_modules\` folder.
-  -\`with cache\`, \`with lockfile\`, \`with node_modules\`: After the first install is done, the install command is run again.
-  -\`with cache\`, \`with lockfile\`: \`node_modules\` are deleted and the install command is run again.
-  -\`with cache\`: \`node_modules\` and the lockfile are deleted and the install command is run again.
-  -\`with lockfile\`: \`node_modules\` and the package cache are deleted and the install command is run again.
-  -\`with cache\`, \`with node_modules\`: The lockfile is deleted and the install command is run again.
-  -\`with node_modules\`, \`with lockfile\`: The package cache is deleted and the install command is run again.
-  -\`with node_modules\`: The package cache and the lockfile is deleted and the install command is run again.
-  -\`updated dependencies\`: Without deleting the previous installation the versions of all dependencies in the \`package.json\` are set to \`'*'\` and the install command is run again.
+
+  - \`clean install\`: How long it takes to run a totally fresh install: no lockfile created, no packages in the cache, no \`node_modules\` folder.
+  - \`with cache\`, \`with lockfile\`, \`with node_modules\`: After the first install is done, the install command is run again.
+  - \`with cache\`, \`with lockfile\`: \`node_modules\` are deleted and the install command is run again.
+  - \`with cache\`: \`node_modules\` and the lockfile are deleted and the install command is run again.
+  - \`with lockfile\`: \`node_modules\` and the package cache are deleted and the install command is run again.
+  - \`with cache\`, \`with node_modules\`: The lockfile is deleted and the install command is run again.
+  - \`with node_modules\`, \`with lockfile\`: The package cache is deleted and the install command is run again.
+  - \`with node_modules\`: The package cache and the lockfile is deleted and the install command is run again.
+  - \`updated dependencies\`: Without deleting the previous installation the versions of all dependencies in the \`package.json\` are set to \`'*'\` and the install command is run again.
 `
 
   await Promise.all(

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ async function run () {
   `
 
   const explanation = stripIndents`
-  Here's a quick explanation of all tests:
+  Here's a quick explanation of how these tests could apply to the real world:
 
   - \`clean install\`: How long it takes to run a totally fresh install: no lockfile present, no packages in the cache, no \`node_modules\` folder.
   - \`with cache\`, \`with lockfile\`, \`with node_modules\`: After the first install is done, the install command is run again.
@@ -159,7 +159,7 @@ async function run () {
   - \`with cache\`, \`with node_modules\`: The lockfile is deleted and the install command is run again.
   - \`with node_modules\`, \`with lockfile\`: The package cache is deleted and the install command is run again.
   - \`with node_modules\`: The package cache and the lockfile is deleted and the install command is run again.
-  - \`updated dependencies\`: Without deleting the previous installation the versions of all dependencies in the \`package.json\` are set to \`'*'\` and the install command is run again.
+  - \`updated dependencies\`: Updating your dependencies by changing the version in the \`package.json\` and running the install command again.
 `
 
   await Promise.all(

--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ const testDescriptions = [
     'with node_modules'
   ],
   [ // updatedDependencies
-    'updated dependencies'
+    'updated',
+    'dependencies'
   ]
 ]
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ const tests = [
   'withLockfile',
   'withWarmCacheAndModules',
   'withWarmModulesAndLockfile',
-  'withWarmModules'
+  'withWarmModules',
+  'updatedDependencies'
 ]
 
 const testDescriptions = [
@@ -73,6 +74,9 @@ const testDescriptions = [
   ],
   [ // withWarmModules
     'with node_modules'
+  ],
+  [ // updatedDependencies
+    'updated dependencies'
   ]
 ]
 
@@ -113,16 +117,17 @@ async function run () {
     sections.push(stripIndents`
       ${fixture.mdDesc}
 
-      | action  | cache | lockfile | node_modules| npm | Yarn | pnpm |
-      | ---     | ---   | ---      | ---         | --- | --- | --- |
-      | install |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} |
-      | install | ✔    | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} |
-      | install | ✔    | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} |
-      | install | ✔    |          |             | ${prettyMs(npmRes.withWarmCache)} | ${prettyMs(yarnRes.withWarmCache)} | ${prettyMs(pnpmRes.withWarmCache)} |
-      | install |      | ✔        |             | ${prettyMs(npmRes.withLockfile)} | ${prettyMs(yarnRes.withLockfile)} | ${prettyMs(pnpmRes.withLockfile)} |
-      | install | ✔    |          | ✔           | ${prettyMs(npmRes.withWarmCacheAndModules)} | ${prettyMs(yarnRes.withWarmCacheAndModules)} | ${prettyMs(pnpmRes.withWarmCacheAndModules)} |
-      | install |      | ✔        | ✔           | ${prettyMs(npmRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnRes.withWarmModulesAndLockfile)} | ${prettyMs(pnpmRes.withWarmModulesAndLockfile)} |
-      | install |      |          | ✔           | ${prettyMs(npmRes.withWarmModules)} | ${prettyMs(yarnRes.withWarmModules)} | ${prettyMs(pnpmRes.withWarmModules)} |
+      | action               | cache | lockfile | node_modules| npm | Yarn | pnpm |
+      | ---                  | ---   | ---      | ---         | --- | --- | --- |
+      | install              |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} |
+      | install              | ✔    | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} |
+      | install              | ✔    | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} |
+      | install              | ✔    |          |             | ${prettyMs(npmRes.withWarmCache)} | ${prettyMs(yarnRes.withWarmCache)} | ${prettyMs(pnpmRes.withWarmCache)} |
+      | install              |      | ✔        |             | ${prettyMs(npmRes.withLockfile)} | ${prettyMs(yarnRes.withLockfile)} | ${prettyMs(pnpmRes.withLockfile)} |
+      | install              | ✔    |          | ✔           | ${prettyMs(npmRes.withWarmCacheAndModules)} | ${prettyMs(yarnRes.withWarmCacheAndModules)} | ${prettyMs(pnpmRes.withWarmCacheAndModules)} |
+      | install              |      | ✔        | ✔           | ${prettyMs(npmRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnRes.withWarmModulesAndLockfile)} | ${prettyMs(pnpmRes.withWarmModulesAndLockfile)} |
+      | install              |      |          | ✔           | ${prettyMs(npmRes.withWarmModules)} | ${prettyMs(yarnRes.withWarmModules)} | ${prettyMs(pnpmRes.withWarmModules)} |
+      | updated dependencies | n/a  | n/a      | n/a         | ${prettyMs(npmRes.updatedDependencies)} | ${prettyMs(yarnRes.updatedDependencies)} | ${prettyMs(pnpmRes.updatedDependencies)} |
 
       ![Graph of the ${fixture.name} results](./results/imgs/${fixture.name}.svg)
     `)

--- a/lib/benchmarkFixture.js
+++ b/lib/benchmarkFixture.js
@@ -5,6 +5,8 @@ const pathKey = require('path-key')
 const cmdsMap = require('./commandsMap')
 const thenify = require('thenify')
 const copy = thenify(require('fs-extra').copy)
+const readFile = thenify(require('fs').readFile)
+const writeFile = thenify(require('fs').writeFile)
 const getFolderSize = thenify(require('get-folder-size'))
 const rimraf = require('rimraf').sync
 
@@ -29,6 +31,28 @@ function createEnv () {
     process.env[pathEnv]
   ].join(path.delimiter)
   return env
+}
+
+async function updateDependenciesInPackageJson (cwd) {
+  const packageJsonPath = path.join(cwd, 'package.json')
+  const buf = await readFile(packageJsonPath)
+  const originalAsString = buf.toString()
+  const parsed = JSON.parse(originalAsString)
+
+  // set all dependency versions to '*'
+  Object.keys(parsed).forEach((key) => {
+    if (key.toLowerCase().includes('dependencies')) {
+      Object.keys(parsed[key]).forEach((dependency) => {
+        parsed[key][dependency] = '*'
+      })
+    }
+  })
+
+  const modifiedAsString = JSON.stringify(parsed)
+  await writeFile(packageJsonPath, modifiedAsString)
+
+  // return the original file so that we can replace it when done
+  return originalAsString
 }
 
 module.exports = async function benchmark (pm, fixture) {
@@ -87,6 +111,15 @@ module.exports = async function benchmark (pm, fixture) {
 
   const size = await getFolderSize(modules)
 
+  console.log('# with updated dependencies')
+
+  // update all dependency versions to '*' and install again
+  const originalPackageJson = await updateDependenciesInPackageJson(cwd)
+  const updatedDependencies = measureInstall(cmd, cwd)
+
+  // revert `package.json` back to its original state, just in case
+  await writeFile(path.join(cwd, 'package.json'), originalPackageJson)
+
   rimraf(cwd)
   return {
     firstInstall,
@@ -97,6 +130,7 @@ module.exports = async function benchmark (pm, fixture) {
     withWarmCacheAndModules,
     withWarmModulesAndLockfile,
     withWarmModules,
+    updatedDependencies,
     size
   }
 }


### PR DESCRIPTION
I've added a new test that measures the speed of updates as discussed in #25. After the (previously) final test all the dependency versions get set to `'*'` and the install command is run again.

I've also added an explanation of all tests in the intro.

**⚠️ Don't merge and run this yet.** Wait for npm to release a new version. Because of the way the code is set up, the lack of an `updatedDependencies` measurement in all three benchmark runs will cause it to crash when trying to render the `README.md`. But because each new package manager version creates new files for the results, these new files _will_ be populated with the new `updatedDependencies` measurements and everything should work fine. Yarn and pnpm already have new versions out (compared to the version of the last benchmark), so we only have to wait for npm to update to a new version. 

Alternatively, you could delete the current npm results (`6.9.0`) and it should also work.

I've hacked a quickfix that prevents the crash on a separate branch so that you can see how it looks: https://github.com/nikoladev/node-package-manager-benchmark/tree/measure-update-speed-INCORRECT-DATA

This closes #4 and closes #25