### PR TITLE
Added child.spawn compatibility for Windows

### DIFF
--- a/lib/benchmarkFixture.js
+++ b/lib/benchmarkFixture.js
@@ -3,6 +3,7 @@ const path = require('path')
 const child = require('child_process')
 const pathKey = require('path-key')
 const thenify = require('thenify')
+const spawn = require("cross-spawn");
 const copy = thenify(require('fs-extra').copy)
 const readFile = thenify(require('fs').readFile)
 const writeFile = thenify(require('fs').writeFile)
@@ -158,7 +159,7 @@ function measureInstall (cmd, cwd) {
   const startTime = Date.now()
 
   console.log(`> ${cmd.name} ${cmd.args.join(' ')}`)
-  const result = child.spawnSync(cmd.name, cmd.args, {env, cwd, stdio: 'inherit'})
+  const result = spawn.sync(cmd.name, cmd.args, { env, cwd, stdio: "inherit" });
   if (result.status !== 0) {
     throw new Error(`${cmd.name} failed with status code ${result.status}`)
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/zkochan/dependency-managers-benchmark#readme",
   "dependencies": {
     "common-tags": "^1.3.1",
-    "cross-spawn": "^5.0.1",
+    "cross-spawn": "^5.1.0",
     "fs-extra": "^1.0.0",
     "get-folder-size": "^1.0.0",
     "load-yaml-file": "^0.1.0",


### PR DESCRIPTION
Fixes #42

Adds [cross-spawn](https://www.npmjs.com/package/cross-spawn) to fix compatibility issues